### PR TITLE
feat: delete lib.firmware.version profile from energy profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ To create a new device implementation for a specific device:
 A hybrid inverter implementation includes:
 
 - Device nameplate information like vendor, model, and serial number
-- Firmware version information
 - Electrical battery management like voltage, current, and power
 - Total inverter power production
 - PV power generation
@@ -69,7 +68,6 @@ description: Hybrid inverter combining PV power generation and battery storage
 
 implements:
   - lib.device.nameplate
-  - lib.firmware.version
   - lib.energy.battery.electrical
   - lib.energy.inverter.total
   - lib.energy.pv.power

--- a/energy/battery.yml
+++ b/energy/battery.yml
@@ -8,4 +8,3 @@ implements:
   - lib.energy.battery.electrical
   - lib.energy.battery.nameplate
   - lib.energy.battery.soc
-  - lib.firmware.version

--- a/energy/battery_inverter/1_phase.yml
+++ b/energy/battery_inverter/1_phase.yml
@@ -14,4 +14,3 @@ implements:
   - lib.energy.inverter.load.power
   - lib.energy.inverter.nameplate
   - lib.energy.inverter.status
-  - lib.firmware.version

--- a/energy/battery_inverter/3_phase.yml
+++ b/energy/battery_inverter/3_phase.yml
@@ -14,4 +14,3 @@ implements:
   - lib.energy.inverter.load.power
   - lib.energy.inverter.nameplate
   - lib.energy.inverter.status
-  - lib.firmware.version

--- a/energy/hybrid_inverter/1_phase.yml
+++ b/energy/hybrid_inverter/1_phase.yml
@@ -15,4 +15,3 @@ implements:
   - lib.energy.inverter.nameplate
   - lib.energy.inverter.status
   - lib.energy.pv.power
-  - lib.firmware.version

--- a/energy/hybrid_inverter/3_phase.yml
+++ b/energy/hybrid_inverter/3_phase.yml
@@ -15,4 +15,3 @@ implements:
   - lib.energy.inverter.nameplate
   - lib.energy.inverter.status
   - lib.energy.pv.power
-  - lib.firmware.version

--- a/energy/power_meter/ac/1_phase.yml
+++ b/energy/power_meter/ac/1_phase.yml
@@ -5,7 +5,6 @@ description: A single-phase power meter profile
 
 implements:
   - lib.device.nameplate
-  - lib.firmware.version
   - lib.energy.power_meter.ac.1_phase
   - lib.energy.power_meter.energy.total
   - lib.energy.power_meter.power

--- a/energy/power_meter/ac/3_phase.yml
+++ b/energy/power_meter/ac/3_phase.yml
@@ -5,7 +5,6 @@ description: A three-phase power meter profile
 
 implements:
   - lib.device.nameplate
-  - lib.firmware.version
   - lib.energy.power_meter.ac.3_phase
   - lib.energy.power_meter.energy.total
   - lib.energy.power_meter.power

--- a/energy/pv_charge_controller.yml
+++ b/energy/pv_charge_controller.yml
@@ -9,4 +9,3 @@ implements:
   - lib.energy.battery.nameplate
   - lib.energy.battery.soc
   - lib.energy.pv.power
-  - lib.firmware.version

--- a/energy/pv_inverter/1_phase.yml
+++ b/energy/pv_inverter/1_phase.yml
@@ -10,4 +10,3 @@ implements:
   - lib.energy.inverter.nameplate
   - lib.energy.inverter.status
   - lib.energy.pv.power
-  - lib.firmware.version

--- a/energy/pv_inverter/3_phase.yml
+++ b/energy/pv_inverter/3_phase.yml
@@ -10,4 +10,3 @@ implements:
   - lib.energy.inverter.nameplate
   - lib.energy.inverter.status
   - lib.energy.pv.power
-  - lib.firmware.version


### PR DESCRIPTION
We decided that _firmware version_:
- is not a core property of energy devices;
- is not used by any automation.

Therefore, we delete the corresponding library profile component from energy device profiles.